### PR TITLE
Bugfix - remove usage of active field in UserVoteItem/AdminVoteItem components

### DIFF
--- a/src/components/AdminVoteItem/AdminVoteItem.tsx
+++ b/src/components/AdminVoteItem/AdminVoteItem.tsx
@@ -4,9 +4,10 @@ import { UserVoteItemProps } from '@/components/UserVoteItem';
 import { VoteItemContainer, VoteItemContent } from './styled';
 
 const AdminVoteItem: React.FC<UserVoteItemProps> = ({
-  active,
-  title
+  title,
+  expires
 }: UserVoteItemProps) => {
+  const active = Date.now() < Date.parse(expires);
   const buttonProps = active
     ? { background: '#f2a024', foreground: '#ffffff' }
     : {};

--- a/src/components/UserVoteItem/UserVoteItem.tsx
+++ b/src/components/UserVoteItem/UserVoteItem.tsx
@@ -13,20 +13,20 @@ import axios from '@/utils/axios';
 
 export interface UserVoteItemProps {
   _id: string;
-  active: boolean;
   title: string;
   subtitle: string;
   content: string;
   choices: string[];
+  expires: string; // ISO Date String
 }
 
 const UserVoteItem: React.FC<UserVoteItemProps> = ({
   _id,
-  active,
   title,
   subtitle,
   content,
-  choices
+  choices,
+  expires
 }: UserVoteItemProps) => {
   /* if we're dealing with only single-choice options, we wouldn't have to
    * keep an entire array, but just the currently selected index.
@@ -36,6 +36,8 @@ const UserVoteItem: React.FC<UserVoteItemProps> = ({
     choices.map(_ => false)
   );
   const [alreadySubmitted, setAlreadySubmitted] = useState<boolean>(false);
+
+  const active = Date.now() < Date.parse(expires);
 
   const handleChoiceClick = (index: number) => {
     setSelectedState(state =>
@@ -82,7 +84,7 @@ const UserVoteItem: React.FC<UserVoteItemProps> = ({
 
         {/* adding `margin-left: auto` puts the rightmost element at the end */}
         <BiseoButton
-          style={{ marginLeft: 'auto', fontWeight: 600 }}
+          style={{ marginLeft: 'auto' }}
           onClick={handleSubmit}
           disabled={alreadySubmitted}
         >

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -86,18 +86,9 @@ const Main: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    socket.on('vote:created', (payload: VoteCreatedPayload) => {
-      const newVoteItem = {
-        active: Date.now() < Date.parse(payload.expires),
-        _id: payload._id,
-        choices: payload.choices,
-        content: payload.content,
-        subtitle: payload.subtitle,
-        title: payload.title
-      };
-
-      setVoteItems(prevState => [newVoteItem, ...prevState]);
-    });
+    socket.on('vote:created', (payload: VoteCreatedPayload) =>
+      setVoteItems(prevState => [payload, ...prevState])
+    );
   }, []);
 
   const MainComponent = isAdmin ? AdminMain : UserMain;


### PR DESCRIPTION
This PR removes the usage of `active` field in {User,Admin}VoteItem component.

the `expires` field conveys the same meaning and is already an existing
field. so no need to use the `active` field really.