### PR TITLE
Feature/editor configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,14 @@
 root = true
 
-[src/**.{tsx,ts}]
+[*]
 charset = utf-8
+end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
+
+[*.{json,js,ts,tsx}]
+indent_size = 2
+
+[{.babelrc,.eslintrc,.prettierrc}]
 indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+webpack.config.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,12 @@
   "rules": {
     "prettier/prettier": 2,
     "better-styled-components/sort-declarations-alphabetically": 2,
-    "no-empty": ["error", { "allowEmptyCatch": true }],
+    "no-empty": [
+      "error",
+      {
+        "allowEmptyCatch": true
+      }
+    ],
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "prettier", "better-styled-components"],
+  "plugins": ["@typescript-eslint", "prettier"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
@@ -11,7 +11,6 @@
   ],
   "rules": {
     "prettier/prettier": 2,
-    "better-styled-components/sort-declarations-alphabetically": 2,
     "no-empty": [
       "error",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,8 @@
         "vars": "all",
         "varsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "react/prop-types": "off"
   },
   "settings": {
     "react": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,9 @@
       "error",
       {
         "args": "all",
-        "argsIgnorePattern": "^_"
+        "argsIgnorePattern": "^_",
+        "vars": "all",
+        "varsIgnorePattern": "^_"
       }
     ]
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,5 +27,10 @@
         "varsIgnorePattern": "^_"
       }
     ]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,8 @@
 {
-    "semi": true,
-    "trailingComma": "none",
-    "singleQuote": true,
-    "bracketSpacing": true,
-    "arrowParens": "avoid",
-    "printWidth": 80
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 80
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "semi": true,
-  "trailingComma": "none",
+  "trailingComma": "es5",
   "singleQuote": true,
   "bracketSpacing": true,
   "arrowParens": "avoid",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4487,16 +4487,6 @@
         "get-stdin": "^6.0.0"
       }
     },
-    "eslint-plugin-better-styled-components": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-better-styled-components/-/eslint-plugin-better-styled-components-1.1.2.tgz",
-      "integrity": "sha512-pGLIv8Z05xnmMyDyLWV65KQs7HU+FN403Tqb5xv3BZvw5kjC3K18/aYm7mcRpLLPse5/lwhX8ieGQKflPgr0xQ==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.2",
-        "requireindex": "~1.1.0"
-      }
-    },
     "eslint-plugin-prettier": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
@@ -8444,12 +8434,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "requireindex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dotenv-webpack": "^4.0.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-better-styled-components": "^1.1.2",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
     "fork-ts-checker-webpack-plugin": "^6.0.3",

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -1,0 +1,6 @@
+export enum MessageEnum {
+  NEW = 'new',
+  MEMBERS = 'members',
+  MESSAGE = 'message',
+  OUT = 'out',
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,5 @@
+import { MessageEnum } from './enums';
+
 export interface Agenda {
   _id: string;
   title: string;
@@ -7,4 +9,11 @@ export interface Agenda {
   votesCountMap: Record<string, number>;
   userChoice: string | null;
   expires: string; // ISO Date String
+}
+
+export interface MessageType {
+  type: MessageEnum;
+  payload: string;
+  issuer?: string;
+  date?: string;
 }

--- a/src/components/AdminBoard/AdminBoard.tsx
+++ b/src/components/AdminBoard/AdminBoard.tsx
@@ -18,7 +18,7 @@ interface VoteCreateResponse {
 
 const AdminBoard: React.FC<AdminBoardProps> = ({
   socket,
-  tabs
+  tabs,
 }: AdminBoardProps) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
   const selectedTab = tabs[selectedTabIndex];

--- a/src/components/AdminBoard/AdminBoard.tsx
+++ b/src/components/AdminBoard/AdminBoard.tsx
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify';
 import AdminTabs from '@/components/AdminTabs';
 import AdminContent from '@/components/AdminContent';
 
-interface AdminBoardProps {
+interface Props {
   socket: SocketIOClient.Socket;
   tabs: {
     title: string;
@@ -16,10 +16,7 @@ interface VoteCreateResponse {
   success: boolean;
 }
 
-const AdminBoard: React.FC<AdminBoardProps> = ({
-  socket,
-  tabs,
-}: AdminBoardProps) => {
+const AdminBoard: React.FC<Props> = ({ socket, tabs }) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
   const selectedTab = tabs[selectedTabIndex];
 

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -9,7 +9,7 @@ import {
   TitleInput,
 } from './styled';
 
-interface AdminContentProps {
+interface Props {
   choices: string[];
   extendable: boolean;
   onVoteCreate: (
@@ -26,11 +26,11 @@ interface FormInputs {
   subtitle: string;
 }
 
-const AdminContent: React.FC<AdminContentProps> = ({
+const AdminContent: React.FC<Props> = ({
   choices,
   extendable,
   onVoteCreate,
-}: AdminContentProps) => {
+}) => {
   const { register, handleSubmit, errors, reset } = useForm<FormInputs>();
   const onSubmit = ({ title, content, subtitle }: FormInputs) => {
     if (choices.length < 1) return;

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -6,7 +6,7 @@ import {
   ButtonGroup,
   ContentTextArea,
   SubtitleInput,
-  TitleInput
+  TitleInput,
 } from './styled';
 
 interface AdminContentProps {
@@ -29,7 +29,7 @@ interface FormInputs {
 const AdminContent: React.FC<AdminContentProps> = ({
   choices,
   extendable,
-  onVoteCreate
+  onVoteCreate,
 }: AdminContentProps) => {
   const { register, handleSubmit, errors, reset } = useForm<FormInputs>();
   const onSubmit = ({ title, content, subtitle }: FormInputs) => {

--- a/src/components/AdminTabs/AdminTabs.tsx
+++ b/src/components/AdminTabs/AdminTabs.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { AdminTab } from './styled';
 
-interface AdminTabsProps {
+interface Props {
   selected: number;
   handleTabClick: React.Dispatch<React.SetStateAction<number>>;
   children?: string[];
 }
 
-const AdminTabs: React.FunctionComponent<AdminTabsProps> = ({
-  selected,
-  handleTabClick,
-  children,
-}) => {
+const AdminTabs: React.FC<Props> = ({ selected, handleTabClick, children }) => {
   return (
     <div style={{ display: 'flex' }}>
       {children.map((title, index) => (

--- a/src/components/AdminTabs/AdminTabs.tsx
+++ b/src/components/AdminTabs/AdminTabs.tsx
@@ -10,7 +10,7 @@ interface AdminTabsProps {
 const AdminTabs: React.FunctionComponent<AdminTabsProps> = ({
   selected,
   handleTabClick,
-  children
+  children,
 }) => {
   return (
     <div style={{ display: 'flex' }}>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,7 @@ import {
   LoginCallback,
   Dashboard,
   Main,
-  AdminPage
+  AdminPage,
 } from '@/pages';
 import BiseoToastContainer from '@/components/BiseoToastContainer';
 

--- a/src/components/AuthedRoute.tsx
+++ b/src/components/AuthedRoute.tsx
@@ -1,14 +1,8 @@
-import React, { ReactChild, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
 import axios from '@/utils/axios';
 
-const AuthedRoute: React.FC<RouteProps> = ({
-  children,
-  ...rest
-}: {
-  children: ReactChild;
-  rest: RouteProps;
-}) => {
+const AuthedRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   const [authed, setAuthed] = useState(null);
 
   useEffect(() => {

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import ChatBoxContent, {
   MessageType,
   MessageEnum,
 } from '@/components/ChatBoxContent';
-import socketio from 'socket.io-client';
-import { getToken } from '@/utils/auth';
 import { ChatBoxContainer, ChatBoxInputGroup } from './styled';
 
 interface ChatBoxProps {
@@ -14,7 +12,7 @@ interface ChatBoxProps {
 const ChatBox: React.FC<ChatBoxProps> = ({ socket }: ChatBoxProps) => {
   const [name, setName] = useState<string>('');
   const [chatlog, setChatlog] = useState<MessageType[]>([]); // elements of chatlog have two required fields: type, payload
-  const [members, setMembers] = useState<string[]>([]);
+  const [_members, setMembers] = useState<string[]>([]);
   const [message, setMessage] = useState('');
 
   /* Initialize socket events for 'name', 'enter', 'members', 'out'.

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -5,11 +5,11 @@ import ChatBoxContent, {
 } from '@/components/ChatBoxContent';
 import { ChatBoxContainer, ChatBoxInputGroup } from './styled';
 
-interface ChatBoxProps {
+interface Props {
   socket: SocketIOClient.Socket;
 }
 
-const ChatBox: React.FC<ChatBoxProps> = ({ socket }: ChatBoxProps) => {
+const ChatBox: React.FC<Props> = ({ socket }) => {
   const [name, setName] = useState<string>('');
   const [chatlog, setChatlog] = useState<MessageType[]>([]); // elements of chatlog have two required fields: type, payload
   const [_members, setMembers] = useState<string[]>([]);

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import ChatBoxContent, {
-  MessageType,
-  MessageEnum,
-} from '@/components/ChatBoxContent';
+import { MessageEnum } from '@/common/enums';
+import { MessageType } from '@/common/types';
+import ChatBoxContent from '@/components/ChatBoxContent';
 import { ChatBoxContainer, ChatBoxInputGroup } from './styled';
 
 interface Props {

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import ChatBoxContent, {
   MessageType,
-  MessageEnum
+  MessageEnum,
 } from '@/components/ChatBoxContent';
 import socketio from 'socket.io-client';
 import { getToken } from '@/utils/auth';
@@ -27,7 +27,7 @@ const ChatBox: React.FC<ChatBoxProps> = ({ socket }: ChatBoxProps) => {
     socket.on('chat:enter', (username: string) => {
       setChatlog(chatlog => [
         { type: MessageEnum.NEW, payload: username },
-        ...chatlog
+        ...chatlog,
       ]);
       setMembers(members => [...members, username]);
     });
@@ -37,7 +37,7 @@ const ChatBox: React.FC<ChatBoxProps> = ({ socket }: ChatBoxProps) => {
     socket.on('chat:out', (username: string) => {
       setChatlog(chatlog => [
         { type: MessageEnum.OUT, payload: username },
-        ...chatlog
+        ...chatlog,
       ]);
       setMembers(members => members.filter(member => member !== username));
     });
@@ -64,9 +64,9 @@ const ChatBox: React.FC<ChatBoxProps> = ({ socket }: ChatBoxProps) => {
             type: MessageEnum.MESSAGE,
             payload: msg.message,
             date: msg.date,
-            ...(user !== name && { issuer: user }) // if user === name, then should be displayed as 'Me'
+            ...(user !== name && { issuer: user }), // if user === name, then should be displayed as 'Me'
           },
-          ...chatlog
+          ...chatlog,
         ]);
       }
     );
@@ -93,9 +93,9 @@ const ChatBox: React.FC<ChatBoxProps> = ({ socket }: ChatBoxProps) => {
       {
         type: MessageEnum.MESSAGE,
         payload: msgObject.message,
-        date: msgObject.date
+        date: msgObject.date,
       },
-      ...chatlog
+      ...chatlog,
     ]);
   };
 

--- a/src/components/ChatBoxContent/ChatBoxContent.tsx
+++ b/src/components/ChatBoxContent/ChatBoxContent.tsx
@@ -5,14 +5,14 @@ import {
   MessageContent,
   MessageDate,
   ChatBoxContainer,
-  ChatBoxScrollable
+  ChatBoxScrollable,
 } from './styled';
 
 export enum MessageEnum {
   NEW = 'new',
   MEMBERS = 'members',
   MESSAGE = 'message',
-  OUT = 'out'
+  OUT = 'out',
 }
 
 export interface MessageType {
@@ -23,7 +23,7 @@ export interface MessageType {
 }
 
 const Message: React.FC<{ message: MessageType }> = ({
-  message
+  message,
 }: {
   message: MessageType;
 }) => {
@@ -79,7 +79,7 @@ const Message: React.FC<{ message: MessageType }> = ({
 };
 
 const ChatBoxContent: React.FC<{ chatlog: MessageType[] }> = ({
-  chatlog
+  chatlog,
 }: {
   chatlog: MessageType[];
 }) => {

--- a/src/components/ChatBoxContent/ChatBoxContent.tsx
+++ b/src/components/ChatBoxContent/ChatBoxContent.tsx
@@ -22,11 +22,11 @@ export interface MessageType {
   date?: string;
 }
 
-const Message: React.FC<{ message: MessageType }> = ({
-  message,
-}: {
+interface MessageProps {
   message: MessageType;
-}) => {
+}
+
+const Message: React.FC<MessageProps> = ({ message }) => {
   const parseDate = (date: string) => {
     const splitted = date.split('T');
     const day = splitted[0];
@@ -78,11 +78,11 @@ const Message: React.FC<{ message: MessageType }> = ({
   );
 };
 
-const ChatBoxContent: React.FC<{ chatlog: MessageType[] }> = ({
-  chatlog,
-}: {
+interface ChatBoxContentProps {
   chatlog: MessageType[];
-}) => {
+}
+
+const ChatBoxContent: React.FC<ChatBoxContentProps> = ({ chatlog }) => {
   return (
     <ChatBoxContainer>
       <ChatBoxScrollable>

--- a/src/components/ChatBoxContent/ChatBoxContent.tsx
+++ b/src/components/ChatBoxContent/ChatBoxContent.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { MessageEnum } from '@/common/enums';
+import { MessageType } from '@/common/types';
 import {
   MessageContainer,
   MessageUsername,
@@ -7,20 +9,6 @@ import {
   ChatBoxContainer,
   ChatBoxScrollable,
 } from './styled';
-
-export enum MessageEnum {
-  NEW = 'new',
-  MEMBERS = 'members',
-  MESSAGE = 'message',
-  OUT = 'out',
-}
-
-export interface MessageType {
-  type: MessageEnum;
-  payload: string;
-  issuer?: string;
-  date?: string;
-}
 
 interface MessageProps {
   message: MessageType;

--- a/src/components/UserAgenda/UserAgenda.tsx
+++ b/src/components/UserAgenda/UserAgenda.tsx
@@ -8,7 +8,7 @@ import {
   ActiveContainerContent,
   ActiveContainerSubtitle,
   ButtonGroup,
-  InactiveContainer
+  InactiveContainer,
 } from './styled';
 
 interface Props extends Agenda {
@@ -24,7 +24,7 @@ const UserAgenda: React.FC<Props> = ({
   expires,
   votesCountMap,
   userChoice,
-  socket
+  socket,
 }: Props) => {
   /* if we're dealing with only single-choice options, we wouldn't have to
    * keep an entire array, but just the currently selected index.

--- a/src/components/UserAgenda/UserAgenda.tsx
+++ b/src/components/UserAgenda/UserAgenda.tsx
@@ -25,7 +25,7 @@ const UserAgenda: React.FC<Props> = ({
   votesCountMap,
   userChoice,
   socket,
-}: Props) => {
+}) => {
   /* if we're dealing with only single-choice options, we wouldn't have to
    * keep an entire array, but just the currently selected index.
    * here we use an array just for potential use of mult-choice options.

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,15 @@
 @font-face {
-    font-family: 'NanumGothic';
-    src: url('./fonts/NanumGothic.ttf') format('truetype');
+  font-family: 'NanumGothic';
+  src: url('./fonts/NanumGothic.ttf') format('truetype');
 }
 
 @font-face {
-    font-family: 'NanumGothic';
-    src: url('./fonts/NanumGothicBold.ttf') format('truetype');
-    font-weight: bold;
+  font-family: 'NanumGothic';
+  src: url('./fonts/NanumGothicBold.ttf') format('truetype');
+  font-weight: bold;
 }
 
 body {
-    font-family: NanumGothic;
-    background-color: rgb(247, 246, 243);
+  font-family: NanumGothic;
+  background-color: rgb(247, 246, 243);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Biseo SSO Front</title>
-    </head>
-    <body>
-        <div id="app"></div>
-    </body>
+  <head>
+    <title>Biseo SSO Front</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
 </html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,6 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import App from './components/App'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './components/App';
+import './index.css';
 
-ReactDOM.render(
-    <App />,
-    document.getElementById("app")
-)
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -5,7 +5,7 @@ const AdminPage: React.FC = () => {
     <>
       <div>
         <h3>Hello, Admin</h3>
-      </div>   
+      </div>
     </>
   );
 };

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -6,7 +6,7 @@ import {
   HeaderGroup,
   MainHeader,
   SubHeader,
-  RedirectAnchor
+  RedirectAnchor,
 } from './styled';
 
 const Login: React.FC = () => {

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -15,10 +15,7 @@ interface CommonMainProps {
   agendas: Agenda[];
 }
 
-const UserMain: React.FC<CommonMainProps> = ({
-  socket,
-  agendas,
-}: CommonMainProps) => {
+const UserMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
   return (
     <UserMainContainer>
       <div className="agendas">
@@ -33,10 +30,7 @@ const UserMain: React.FC<CommonMainProps> = ({
   );
 };
 
-const AdminMain: React.FC<CommonMainProps> = ({
-  socket,
-  agendas,
-}: CommonMainProps) => {
+const AdminMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
   return (
     <AdminMainContainer>
       <div className="agendas">

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -17,7 +17,7 @@ interface CommonMainProps {
 
 const UserMain: React.FC<CommonMainProps> = ({
   socket,
-  agendas
+  agendas,
 }: CommonMainProps) => {
   return (
     <UserMainContainer>
@@ -35,7 +35,7 @@ const UserMain: React.FC<CommonMainProps> = ({
 
 const AdminMain: React.FC<CommonMainProps> = ({
   socket,
-  agendas
+  agendas,
 }: CommonMainProps) => {
   return (
     <AdminMainContainer>
@@ -62,7 +62,7 @@ const Main: React.FC = () => {
       io(process.env.SOCKET_URL, {
         transports: ['websocket'],
         upgrade: false,
-        query: `token=${getToken()}`
+        query: `token=${getToken()}`,
       }),
     []
   );
@@ -81,7 +81,7 @@ const Main: React.FC = () => {
     socket.on('agenda:created', (payload: Agenda) => {
       const newAgenda = {
         ...payload,
-        userChoice: null
+        userChoice: null,
       };
       setAgendas(prevState => [newAgenda, ...prevState]);
     });

--- a/src/pages/Main/mock.ts
+++ b/src/pages/Main/mock.ts
@@ -2,16 +2,16 @@ export const mockTabs = [
   {
     title: '찬반 투표',
     choices: ['찬성', '반대'],
-    extendableChoices: false
+    extendableChoices: false,
   },
   {
     title: '회장 선거',
     choices: [],
-    extendableChoices: true
+    extendableChoices: true,
   },
   {
     title: 'Baz',
     choices: ['D', 'E'],
-    extendableChoices: false
-  }
+    extendableChoices: false,
+  },
 ];

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,10 +1,9 @@
-export const getToken = (): string => localStorage.getItem('biseo-jwt')
+export const getToken = (): string => localStorage.getItem('biseo-jwt');
 
 export const saveToken = (token: string): void => {
-  localStorage.setItem('biseo-jwt', token)
-}
+  localStorage.setItem('biseo-jwt', token);
+};
 
 export const logout = (): void => {
-  localStorage.removeItem('biseo-jwt')
-}
-
+  localStorage.removeItem('biseo-jwt');
+};

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const instance = axios.create({
   baseURL: process.env.API_URL,
-  withCredentials: true
+  withCredentials: true,
 });
 
 instance.interceptors.request.use(config => {
@@ -10,7 +10,7 @@ instance.interceptors.request.use(config => {
 
   if (token)
     config.headers = {
-      'X-Access-Token': `Bearer ${token}`
+      'X-Access-Token': `Bearer ${token}`,
     };
 
   return config;

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -2,12 +2,12 @@ export const size = {
   mobile: '375px',
   tablet: '768px',
   laptop: '1024px',
-  laptopL: '1440px'
+  laptopL: '1440px',
 };
 
 export const device = {
   mobile: `(min-width: ${size.mobile})`,
   tablet: `(min-width: ${size.tablet})`,
   laptop: `(min-width: ${size.laptop})`,
-  laptopL: `(min-width: ${size.laptopL})`
+  laptopL: `(min-width: ${size.laptopL})`,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "esModuleInterop": true,
-        "target": "es6",
-        "moduleResolution": "node",
-        "sourceMap": true,
-        "outDir": "dist",
-        "jsx": "react",
-        "baseUrl": "./src",
-        "paths": {
-            "@/*": ["./*"]
-        }
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es6",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist",
+    "jsx": "react",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,24 +10,24 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist'),
     filename: 'bundle.js',
-    publicPath: '/'
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     alias: {
-      '@': path.resolve(__dirname, 'src')
-    }
+      '@': path.resolve(__dirname, 'src'),
+    },
   },
   module: {
     rules: [
       {
         test: /\.tsx?$/,
         exclude: /node_modules/,
-        use: 'babel-loader'
+        use: 'babel-loader',
       },
       {
         test: /\.css$/i,
-        use: ['style-loader', 'css-loader']
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.woff($|\?)|\.woff2($|\?)|\.ttf($|\?)|\.eot($|\?)|\.svg($|\?)|\.(png|jpg|gif)($|\?)/,
@@ -35,25 +35,25 @@ module.exports = {
           {
             loader: 'url-loader',
             options: {
-              esModule: false
-            }
-          }
-        ]
-      }
-    ]
+              esModule: false,
+            },
+          },
+        ],
+      },
+    ],
   },
   plugins: [
     new ForkTsCheckerWebpackPlugin(),
     new HtmlWebpackPlugin({
-      template: './src/index.html'
+      template: './src/index.html',
     }),
     new CleanWebpackPlugin(),
-    new Dotenv()
+    new Dotenv(),
   ],
   devServer: {
     port: 8000,
     host: '0.0.0.0',
     public: env.parsed.PUBLIC_URL,
-    historyApiFallback: true
-  }
+    historyApiFallback: true,
+  },
 };


### PR DESCRIPTION
This PR:
* adds additional rules to `.editorconfig` (for `.babelrc`, `.eslintrc`, `.prettierrc` files)
* update `.eslintrc`
  * turn off `react/prop-types`
  * ignore variables starting with `_`
  * ignore `webpack.config.js`
  * remove `better-styled-components` plugin
* update `.prettierrc`
  * set `trailingComma` option to `es5`
* move common enums and types into separate file