### PR TITLE
Feature/allowed hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 # URL of api + socket server
-# e.g. http://localhost:3000
-SERVER_URL=""
-
+# e.g. http://localhost:3000, http://api.server.com:8000
+SERVER_URL=

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,3 @@
 # e.g. http://localhost:3000
 SERVER_URL=""
 
-# Public URL to be used in webpack config WITHOUT scheme
-# e.g. localhost:8000
-PUBLIC_URL=""

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-plugin-styled-components": "^1.11.1",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.5.2",
-    "dotenv": "^8.2.0",
     "dotenv-webpack": "^4.0.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,5 +53,6 @@ module.exports = {
     port: 8000,
     host: '0.0.0.0',
     historyApiFallback: true,
+    allowedHosts: ['.sparcs.org', 'localhost'],
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
-const env = require('dotenv').config();
 
 module.exports = {
   entry: './src/index.tsx',
@@ -53,7 +52,6 @@ module.exports = {
   devServer: {
     port: 8000,
     host: '0.0.0.0',
-    public: env.parsed.PUBLIC_URL,
     historyApiFallback: true,
   },
 };


### PR DESCRIPTION
This PR drops the `PUBLIC_URL` environment variable and `public` option in webpack config in favor of `allowedHosts` option in webpack.

기존에 `PUBLIC_URL` 환경변수의 입력이 필요했던 이유는 webpack-dev-server에서 host checking이 필요했기 때문입니다.
webpack-dev-server에서 host checking은 이 repo를 원격 서버에서 실행시킬 때 일종의 보안설정입니다.
`disableHostCheck`를 이용해 host checking을 아예 하지 않을 수도 있지만 개발 모드라도 credential들이 접근 가능할 수 있기 때문에 이와 같은 설정이 있었습니다.
[webpack-dev-server disableHostCheck 보안 관련 이슈](https://github.com/webpack/webpack-dev-server/issues/887)

그러나 개발환경을 설정할 때마다 이를 입력하는 것이 번거롭기에 사실상 사용하는 두 개의 도메인, `.sparcs.org` 와 `localhost`를 `allowedHosts`로 미리 등록해 두었습니다. 이와 동시에 `webpack.config.js`에서는 `.env` 파일을 읽어올 필요가 없어졌기에 `dotenv` 디펜던시를 제거하였습니다.