### PR TITLE
feat(env): go back to using public url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # URL of api + socket server
 # e.g. http://localhost:3000, http://api.server.com:8000
 SERVER_URL=
+
+# where the dev server is running on
+# e.g. http://localhost:8000, http://ssal.sparcs.org:8000
+PUBLIC_URL=

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-plugin-styled-components": "^1.11.1",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.5.2",
+    "dotenv": "^8.2.0",
     "dotenv-webpack": "^4.0.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
+const { parsed } = require('dotenv').config();
 
 module.exports = {
   entry: './src/index.tsx',
@@ -53,6 +54,6 @@ module.exports = {
     port: 8000,
     host: '0.0.0.0',
     historyApiFallback: true,
-    allowedHosts: ['.sparcs.org', 'localhost'],
+    public: parsed.PUBLIC_URL,
   },
 };


### PR DESCRIPTION
This PR brings back the `PUBLIC_URL` env variable to meet CORS restrictions.