### PR TITLE
Feature/auth api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ SERVER_URL=
 # where the dev server is running on. WITHOUT protocol(http, https)
 # e.g. localhost:8000, ssal.sparcs.org:30000
 PUBLIC_URL=
+
+# URL of authorization server
+# if empty, it will fallback to SERVER_URL
+AUTH_URL=

--- a/src/components/AuthedRoute.tsx
+++ b/src/components/AuthedRoute.tsx
@@ -1,16 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
-import axios from '@/utils/axios';
+import { checkLoginStatus } from '@/utils/auth';
 
 const AuthedRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   const [authed, setAuthed] = useState(null);
 
   useEffect(() => {
-    axios
-      .get('/auth/check')
-      .then(({ data }) => {
-        setAuthed(data.success);
-      })
+    checkLoginStatus()
+      .then(isLoggedIn => setAuthed(isLoggedIn))
       .catch(() => setAuthed(false));
   }, []);
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { logout } from '../utils/auth';
+import { logout } from '@/utils/auth';
 
 const Dashboard: React.FC = () => {
   const history = useHistory();

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
-import axios from '@/utils/axios';
+import { checkLoginStatus } from '@/utils/auth';
 import {
   Container,
   HeaderGroup,
@@ -13,11 +13,8 @@ const Login: React.FC = () => {
   const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
 
   useEffect(() => {
-    axios
-      .get('/auth/check')
-      .then(({ data }) => {
-        setLoggedIn(data.success);
-      })
+    checkLoginStatus()
+      .then(isLoggedIn => setLoggedIn(isLoggedIn))
       .catch(() => setLoggedIn(false));
   }, []);
 

--- a/src/pages/LoginCallback.tsx
+++ b/src/pages/LoginCallback.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, Redirect } from 'react-router-dom';
 import querystring from 'querystring';
-import axios from '@/utils/axios';
-import { saveToken } from '@/utils/auth';
+import { requestToken, saveToken } from '@/utils/auth';
 
 const LoginCallback: React.FC = () => {
   const location = useLocation();
@@ -13,16 +12,14 @@ const LoginCallback: React.FC = () => {
   const [valid, setValid] = useState(null);
 
   useEffect(() => {
-    axios
-      .get(`/auth/login/callback?code=${code}&state=${state}`)
-      .then(({ data }) => {
-        if (data.token) {
-          saveToken(data.token);
-          setValid(true);
-        } else {
-          setValid(false);
-        }
-      });
+    requestToken(code as string, state as string).then(token => {
+      if (token) {
+        saveToken(token);
+        setValid(true);
+      } else {
+        setValid(false);
+      }
+    });
   }, []);
 
   if (valid === null) return <div>Loading...</div>;

--- a/src/pages/LoginRedirect.tsx
+++ b/src/pages/LoginRedirect.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-import axios from '@/utils/axios';
+import { requestRedirectURL } from '@/utils/auth';
 
 const LoginRedirect: React.FC = () => {
   useEffect(() => {
-    axios.post('/auth/login').then(({ data: { url } }) => {
+    requestRedirectURL().then(url => {
       window.location.href = url;
     });
   }, []);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,3 +1,24 @@
+import axios from 'axios';
+
+const AUTH_URL = process.env.AUTH_URL ?? process.env.SERVER_URL;
+if (typeof AUTH_URL !== 'string') throw new Error('AUTH_URL not set!');
+
+const auth = axios.create({
+  baseURL: `${AUTH_URL}/api`,
+  withCredentials: true,
+});
+
+auth.interceptors.request.use(config => {
+  const token = localStorage.getItem('biseo-jwt');
+
+  if (token)
+    config.headers = {
+      'X-Access-Token': `Bearer ${token}`,
+    };
+
+  return config;
+});
+
 export const getToken = (): string => localStorage.getItem('biseo-jwt');
 
 export const saveToken = (token: string): void => {
@@ -6,4 +27,43 @@ export const saveToken = (token: string): void => {
 
 export const logout = (): void => {
   localStorage.removeItem('biseo-jwt');
+};
+
+export const requestToken = async (
+  code: string,
+  state: string
+): Promise<string> => {
+  type TokenResponse = { data: { token: string } };
+
+  const response: TokenResponse = await auth
+    .get(`${AUTH_URL}/api/auth/login/callback?code=${code}&state=${state}`)
+    .catch(() => {
+      throw new Error('Login callback error!');
+    });
+
+  return response.data.token;
+};
+
+export const requestRedirectURL = async (): Promise<string> => {
+  type RedirectURLResponse = { data: { url: string } };
+
+  const response: RedirectURLResponse = await auth
+    .post(`${AUTH_URL}/api/auth/login`)
+    .catch(() => {
+      throw new Error('Redirect URL fetch error!');
+    });
+
+  return response.data.url;
+};
+
+export const checkLoginStatus = async (): Promise<boolean> => {
+  type LoggedIn = { success: boolean };
+
+  const { data }: { data: LoggedIn } = await auth
+    .get(`${AUTH_URL}/api/auth/check`)
+    .catch(() => {
+      throw new Error('Login check error!');
+    });
+
+  return data.success;
 };


### PR DESCRIPTION
This PR adds an option to use a separate server for authorization. One can now specify the auth server address in the `AUTH_URL` environment variable.

만약 인증 서버를 별도로 사용하게 된다면 인증 서버와 API 서버가 사용하는 token 비밀 키가 같아야 함을 유의해야 합니다!