### PR TITLE
fix: prevent rerendering all agendas in Main

### DIFF
--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -80,30 +80,32 @@ const Main: React.FC = () => {
       };
       setAgendas(prevState => [newAgenda, ...prevState]);
     });
-  }, []);
 
-  useEffect(() => {
     socket.on('agenda:started', (payload: Agenda) => {
-      const newAgendas = agendas.map(agenda => {
-        if (agenda._id == payload._id) return { ...payload, userChoice: null };
-        else return agenda;
+      setAgendas(agendas => {
+        return agendas.map(agenda => {
+          if (agenda._id === payload._id)
+            return { ...payload, userChoice: null };
+          else return agenda;
+        });
       });
-      setAgendas(newAgendas);
     });
 
     socket.on('agenda:terminated', (payload: Agenda) => {
-      const newAgendas = agendas.map(agenda => {
-        if (agenda._id == payload._id) return payload;
-        else return agenda;
+      setAgendas(agendas => {
+        return agendas.map(agenda => {
+          if (agenda._id === payload._id) return payload;
+          else return agenda;
+        });
       });
-      setAgendas(newAgendas);
     });
-  }, [agendas]);
+  }, []);
 
   const MainComponent = isAdmin ? AdminMain : UserMain;
   const filteredAgendas = isAdmin
     ? agendas
-    : agendas.filter(agenda => agenda.status != AgendaStatus.PREPARE);
+    : agendas.filter(agenda => agenda.status !== AgendaStatus.PREPARE);
+
   return (
     <div>
       <button onClick={() => setIsAdmin(prevState => !prevState)}>


### PR DESCRIPTION
Main 쪽에서 `agendas` 변수가 바뀌면 모든 Agenda 컴포넌트가 rerender되면서 state가 원상복귀되는 버그를 고쳤습니다.