### PR TITLE
Feature/admin agenda details

### DIFF
--- a/src/components/AdminAgenda/AdminAgenda.tsx
+++ b/src/components/AdminAgenda/AdminAgenda.tsx
@@ -3,11 +3,16 @@ import { toast } from 'react-toastify';
 import { Agenda } from '@/common/types';
 import { AgendaStatus } from '@/common/enums';
 import BiseoButton from '@/components/BiseoButton';
-import { AgendaContainer, AgendaContent, AgendaButton } from './styled';
+import {
+  AgendaContainer,
+  AgendaContent,
+  AgendaButton,
+  AgendaContentLeft,
+} from './styled';
 import {
   ActiveContainerTitle,
+  ActiveContainerProgress,
   ActiveContainerContent,
-  ActiveContainerSubtitle,
 } from '../UserAgenda/styled';
 import EditIcon from './Edit.svg';
 
@@ -26,6 +31,7 @@ const AdminAgenda: React.FC<Props> = ({
   subtitle,
   choices,
   expires,
+  votesCountMap,
   status,
   socket,
 }) => {
@@ -110,17 +116,37 @@ const AdminAgenda: React.FC<Props> = ({
     [socket]
   );
 
+  const totalParticipants = votesCountMap
+    ? Object.values(votesCountMap).reduce((sum, count) => sum + count, 0)
+    : 0;
+
+  const voteResultMessage =
+    votesCountMap && Object.keys(votesCountMap).length > 0
+      ? '중 ' +
+        Object.entries(votesCountMap)
+          .sort()
+          .map(([choice, count]) => `${choice} ${count}명`)
+          .join(', ')
+      : '';
+
   return showDetails ? (
-    <AgendaContainer onClick={onClick}>
-      <ActiveContainerTitle>{title}</ActiveContainerTitle>
-      <ActiveContainerContent>{content}</ActiveContainerContent>
-      <ActiveContainerSubtitle>{subtitle}</ActiveContainerSubtitle>
-      <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
-        {buttonText()}
-      </BiseoButton>
+    <AgendaContainer onClick={onClick} detailed={showDetails}>
+      <AgendaContentLeft>
+        <ActiveContainerTitle>{title}</ActiveContainerTitle>
+        <ActiveContainerProgress>
+          {`재석 ${totalParticipants}명 ${voteResultMessage}`}
+        </ActiveContainerProgress>
+        <ActiveContainerContent>{content}</ActiveContainerContent>
+      </AgendaContentLeft>
+      <AgendaButton>
+        <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
+          {buttonText()}
+        </BiseoButton>
+        <EditIcon />
+      </AgendaButton>
     </AgendaContainer>
   ) : (
-    <AgendaContainer onClick={onClick}>
+    <AgendaContainer onClick={onClick} detailed={showDetails}>
       <AgendaContent>
         {title}
         <AgendaButton>

--- a/src/components/AdminAgenda/styled.tsx
+++ b/src/components/AdminAgenda/styled.tsx
@@ -1,7 +1,14 @@
 import styled from 'styled-components';
 
+interface AgendaContainerProps {
+  detailed: boolean;
+}
+
 export const AgendaContainer = styled.div`
   align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   background: #ffffff;
   border-bottom-left-radius: 10px;
   border-top-left-radius: 10px;
@@ -11,7 +18,8 @@ export const AgendaContainer = styled.div`
   position: relative;
 
   &::before {
-    background: #f2a024;
+    background: ${(props: AgendaContainerProps) =>
+      props.detailed ? '#f2a024' : '#8c8c8c'};
     border-bottom-left-radius: 5px;
     border-top-left-radius: 5px;
     content: '';
@@ -27,9 +35,16 @@ export const AgendaContent = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;
+  width: 100%;
 `;
 
 export const AgendaButton = styled.div`
   align-items: center;
   display: flex;
+`;
+
+export const AgendaContentLeft = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 66%;
 `;

--- a/src/components/UserAgenda/styled.tsx
+++ b/src/components/UserAgenda/styled.tsx
@@ -12,6 +12,12 @@ export const ActiveContainerTitle = styled.div`
   font-weight: 700;
 `;
 
+export const ActiveContainerProgress = styled.div`
+  font-size: 1rem;
+  font-weight: 400;
+  margin-top: 20px;
+`;
+
 export const ActiveContainerContent = styled.div`
   border: none;
   border-bottom: 1px solid #f2a024;

--- a/src/pages/Main/mock.ts
+++ b/src/pages/Main/mock.ts
@@ -10,8 +10,8 @@ export const mockTabs = [
     extendableChoices: true,
   },
   {
-    title: 'Baz',
-    choices: ['D', 'E'],
-    extendableChoices: false,
+    title: '새 탬플릿',
+    choices: [],
+    extendableChoices: true,
   },
 ];


### PR DESCRIPTION
변경사항
- Agenda 탭에서 '새 탬플릿'으로 이름 변경
- Agenda 기본 색상 및 세부사항 열람 시 인터페이스 수정

BiseoButton에서 폰트크기를 0.9rem으로 적용하여 테스트를 하였지만 승혁이 pr에서 비서버튼 폰트크기가 0.9rem으로 변경되어 있어 그 부분은 넣진 않았습니다

--------------------

agenda 탭에서 '새 탬플릿'으로 이름 변경 (mock 파일 변경)
<img width="741" alt="스크린샷 2021-09-26 오후 1 59 11" src="https://user-images.githubusercontent.com/60319371/134794338-b10da632-26ec-400a-b83e-218a7a6dcd76.png">

agenda에서 기본 색상 회색으로 변경
<img width="585" alt="스크린샷 2021-09-26 오후 1 59 37" src="https://user-images.githubusercontent.com/60319371/134794339-5f4ccc97-8870-42a4-9f2c-2cf9a412b7de.png">

agenda를 클릭하여 세부사항 형식 변경
<img width="588" alt="스크린샷 2021-09-26 오후 2 00 04" src="https://user-images.githubusercontent.com/60319371/134794341-a8f9245d-9eb2-4dc1-97e0-f4406bf325db.png">
