### PR TITLE
Feature/edit agenda

### DIFF
--- a/src/components/AdminAgenda/AdminAgenda.tsx
+++ b/src/components/AdminAgenda/AdminAgenda.tsx
@@ -18,6 +18,7 @@ import EditIcon from './Edit.svg';
 
 interface Props extends Agenda {
   socket: SocketIOClient.Socket;
+  onEdit: (_id: string) => void;
 }
 
 interface AgendaResponse {
@@ -34,6 +35,7 @@ const AdminAgenda: React.FC<Props> = ({
   votesCountMap,
   status,
   socket,
+  onEdit,
 }) => {
   const active = Date.now() < Date.parse(expires);
   const buttonProps = () => {
@@ -91,21 +93,6 @@ const AdminAgenda: React.FC<Props> = ({
     }
   };
 
-  const onClickAdminEdit = useCallback(
-    (_id, title, content, subtitle, choices): void => {
-      socket.emit(
-        'admin:edit',
-        _id,
-        { title, content, subtitle, choices },
-        (res: AgendaResponse) => {
-          if (res.success) toast.success('🦄 Agenda edited Successfully!');
-          else toast.error('Agenda Edition Error!');
-        }
-      );
-    },
-    [socket]
-  );
-
   const onClickAdminDelete = useCallback(
     (_id): void => {
       socket.emit('admin:delete', _id, (res: AgendaResponse) => {
@@ -115,6 +102,11 @@ const AdminAgenda: React.FC<Props> = ({
     },
     [socket]
   );
+
+  const onClickEditIcon = e => {
+    e.stopPropagation();
+    onEdit(_id);
+  };
 
   const totalParticipants = votesCountMap
     ? Object.values(votesCountMap).reduce((sum, count) => sum + count, 0)
@@ -142,7 +134,7 @@ const AdminAgenda: React.FC<Props> = ({
         <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
           {buttonText()}
         </BiseoButton>
-        <EditIcon />
+        <EditIcon onClick={onClickEditIcon} />
       </AgendaButton>
     </AgendaContainer>
   ) : (
@@ -153,7 +145,7 @@ const AdminAgenda: React.FC<Props> = ({
           <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
             {buttonText()}
           </BiseoButton>
-          <EditIcon />
+          <EditIcon onClick={onClickEditIcon} />
         </AgendaButton>
       </AgendaContent>
     </AgendaContainer>

--- a/src/components/AdminAgenda/AdminAgenda.tsx
+++ b/src/components/AdminAgenda/AdminAgenda.tsx
@@ -93,16 +93,6 @@ const AdminAgenda: React.FC<Props> = ({
     }
   };
 
-  const onClickAdminDelete = useCallback(
-    (_id): void => {
-      socket.emit('admin:delete', _id, (res: AgendaResponse) => {
-        if (res.success) toast.success('🦄 Agenda deleted Successfully!');
-        else toast.error('Agenda Deletion Error!');
-      });
-    },
-    [socket]
-  );
-
   const onClickEditIcon = e => {
     e.stopPropagation();
     onEdit(_id);

--- a/src/components/AdminAgenda/AdminAgenda.tsx
+++ b/src/components/AdminAgenda/AdminAgenda.tsx
@@ -124,7 +124,7 @@ const AdminAgenda: React.FC<Props> = ({
         <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
           {buttonText()}
         </BiseoButton>
-        <EditIcon onClick={onClickEditIcon} />
+        <EditIcon onClick={onClickEditIcon} style={{ cursor: 'pointer' }} />
       </AgendaButton>
     </AgendaContainer>
   ) : (
@@ -135,7 +135,7 @@ const AdminAgenda: React.FC<Props> = ({
           <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
             {buttonText()}
           </BiseoButton>
-          <EditIcon onClick={onClickEditIcon} />
+          <EditIcon onClick={onClickEditIcon} style={{ cursor: 'pointer' }} />
         </AgendaButton>
       </AgendaContent>
     </AgendaContainer>

--- a/src/components/AdminBoard/AdminBoard.tsx
+++ b/src/components/AdminBoard/AdminBoard.tsx
@@ -80,11 +80,7 @@ const AdminBoard: React.FC<Props> = ({
 
   return isEdit ? (
     <AdminContentEdit
-      _id={targetAgenda._id}
-      title={targetAgenda.title}
-      content={targetAgenda.content}
-      subtitle={targetAgenda.subtitle}
-      choices={targetAgenda.choices}
+      agenda={targetAgenda}
       extendable={false}
       onVoteEdit={onAgendaEdit}
       onVoteDelete={onClickAdminDelete}

--- a/src/components/AdminBoard/AdminBoard.tsx
+++ b/src/components/AdminBoard/AdminBoard.tsx
@@ -67,6 +67,17 @@ const AdminBoard: React.FC<Props> = ({
     [socket]
   );
 
+  const onClickAdminDelete = useCallback(
+    (_id): void => {
+      socket.emit('admin:delete', _id, (res: AgendaResponse) => {
+        if (res.success) toast.success('🦄 Agenda deleted Successfully!');
+        else toast.error('Agenda Deletion Error!');
+      });
+      confirmEdit(_id);
+    },
+    [socket]
+  );
+
   return isEdit ? (
     <AdminContentEdit
       _id={targetAgenda._id}
@@ -76,6 +87,8 @@ const AdminBoard: React.FC<Props> = ({
       choices={targetAgenda.choices}
       extendable={false}
       onVoteEdit={onAgendaEdit}
+      onVoteDelete={onClickAdminDelete}
+      exitEditMode={confirmEdit}
     />
   ) : (
     <>

--- a/src/components/AdminBoard/AdminBoard.tsx
+++ b/src/components/AdminBoard/AdminBoard.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useState } from 'react';
 import { toast } from 'react-toastify';
 import AdminTabs from '@/components/AdminTabs';
-import AdminContent from '@/components/AdminContent';
+import {
+  AdminContentCreate,
+  AdminContentEdit,
+} from '@/components/AdminContent';
+import { Agenda } from '@/common/types';
 
 interface Props {
   socket: SocketIOClient.Socket;
@@ -10,13 +14,26 @@ interface Props {
     choices: string[];
     extendableChoices?: boolean;
   }[];
+  isEdit: boolean;
+  targetAgenda: Agenda;
+  confirmEdit: (_id: string) => void;
 }
 
 interface VoteCreateResponse {
   success: boolean;
 }
 
-const AdminBoard: React.FC<Props> = ({ socket, tabs }) => {
+interface AgendaResponse {
+  success: boolean;
+}
+
+const AdminBoard: React.FC<Props> = ({
+  socket,
+  tabs,
+  isEdit,
+  targetAgenda,
+  confirmEdit,
+}) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
   const selectedTab = tabs[selectedTabIndex];
 
@@ -34,7 +51,33 @@ const AdminBoard: React.FC<Props> = ({ socket, tabs }) => {
     [socket]
   );
 
-  return (
+  const onAgendaEdit = useCallback(
+    (_id, title, content, subtitle, choices): void => {
+      socket.emit(
+        'admin:edit',
+        _id,
+        { title, content, subtitle, choices },
+        (res: AgendaResponse) => {
+          if (res.success) toast.success('🦄 Agenda edited Successfully!');
+          else toast.error('Agenda Edition Error!');
+        }
+      );
+      confirmEdit(_id);
+    },
+    [socket]
+  );
+
+  return isEdit ? (
+    <AdminContentEdit
+      _id={targetAgenda._id}
+      title={targetAgenda.title}
+      content={targetAgenda.content}
+      subtitle={targetAgenda.subtitle}
+      choices={targetAgenda.choices}
+      extendable={false}
+      onVoteEdit={onAgendaEdit}
+    />
+  ) : (
     <>
       <AdminTabs
         selected={selectedTabIndex}
@@ -42,7 +85,7 @@ const AdminBoard: React.FC<Props> = ({ socket, tabs }) => {
       >
         {tabs.map(tab => tab.title)}
       </AdminTabs>
-      <AdminContent
+      <AdminContentCreate
         choices={selectedTab.choices}
         extendable={selectedTab.extendableChoices}
         onVoteCreate={onVoteCreate}

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import BiseoButton from '@/components/BiseoButton';
+import { Agenda } from '@/common/types';
+import { AgendaStatus } from '@/common/enums';
 import {
   AdminContentContainer,
   ButtonGroup,
@@ -9,19 +11,20 @@ import {
   TitleInput,
 } from './styled';
 
-interface CommonProps {
-  _id?: string;
-  title?: string;
-  content?: string;
-  subtitle?: string;
-  choices?: string[];
-  extendable?: boolean;
-  onVoteCreate?: (
+interface AdminContentCreateProps {
+  choices: string[];
+  extendable: boolean;
+  onVoteCreate: (
     title: string,
     content: string,
     subtitle: string,
     choices: string[]
   ) => void;
+}
+
+interface AdminContentEditProps {
+  agenda: Agenda;
+  extendable: boolean;
   onVoteEdit?: (
     _id: string,
     title: string,
@@ -39,7 +42,7 @@ interface FormInputs {
   subtitle: string;
 }
 
-export const AdminContentCreate: React.FC<CommonProps> = ({
+export const AdminContentCreate: React.FC<AdminContentCreateProps> = ({
   choices,
   extendable,
   onVoteCreate,
@@ -89,17 +92,15 @@ export const AdminContentCreate: React.FC<CommonProps> = ({
   );
 };
 
-export const AdminContentEdit: React.FC<CommonProps> = ({
-  _id,
-  title,
-  content,
-  subtitle,
-  choices,
+export const AdminContentEdit: React.FC<AdminContentEditProps> = ({
+  agenda,
   extendable,
   onVoteEdit,
   onVoteDelete,
   exitEditMode,
 }) => {
+  const { _id, title, content, subtitle, choices, expires, status } = agenda;
+
   const { register, handleSubmit, errors, reset } = useForm<FormInputs>({
     defaultValues: {
       title: title,
@@ -107,11 +108,14 @@ export const AdminContentEdit: React.FC<CommonProps> = ({
       subtitle: subtitle,
     },
   });
+
   const onSubmit = ({ title, content, subtitle }: FormInputs) => {
     if (choices.length < 1) return;
     onVoteEdit(_id, title, content, subtitle, choices);
     reset();
   };
+
+  const active = Date.now() < Date.parse(expires);
 
   return (
     <AdminContentContainer onSubmit={handleSubmit(onSubmit)}>
@@ -143,7 +147,12 @@ export const AdminContentEdit: React.FC<CommonProps> = ({
         {extendable && <BiseoButton>+</BiseoButton>}
       </ButtonGroup>
       <ButtonGroup alignRight={true}>
-        <BiseoButton type="submit" background="#f2a024" foreground="#ffffff">
+        <BiseoButton
+          type="submit"
+          background="#f2a024"
+          foreground="#ffffff"
+          disabled={!(active && status === AgendaStatus.PREPARE)}
+        >
           수정
         </BiseoButton>
         <BiseoButton
@@ -153,6 +162,7 @@ export const AdminContentEdit: React.FC<CommonProps> = ({
           onClick={() => {
             onVoteDelete(_id);
           }}
+          disabled={active && status === AgendaStatus.PROGRESS}
         >
           삭제
         </BiseoButton>

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -25,15 +25,15 @@ interface AdminContentCreateProps {
 interface AdminContentEditProps {
   agenda: Agenda;
   extendable: boolean;
-  onVoteEdit?: (
+  onVoteEdit: (
     _id: string,
     title: string,
     content: string,
     subtitle: string,
     choices: string[]
   ) => void;
-  onVoteDelete?: (_id: string) => void;
-  exitEditMode?: (_id: string) => void;
+  onVoteDelete: (_id: string) => void;
+  exitEditMode: (_id: string) => void;
 }
 
 interface FormInputs {
@@ -121,19 +121,16 @@ export const AdminContentEdit: React.FC<AdminContentEditProps> = ({
     <AdminContentContainer onSubmit={handleSubmit(onSubmit)}>
       <TitleInput
         name="title"
-        placeholder="투표 제목을 입력하세요"
         className={errors.title && 'error'}
         ref={register({ required: true })}
       />
       <ContentTextArea
         name="content"
-        placeholder="투표 내용을 입력하세요"
         className={errors.content && 'error'}
         ref={register({ required: true })}
       />
       <SubtitleInput
         name="subtitle"
-        placeholder="의결문안을 입력하세요"
         className={errors.subtitle && 'error'}
         ref={register({ required: true })}
       />

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -9,10 +9,21 @@ import {
   TitleInput,
 } from './styled';
 
-interface Props {
-  choices: string[];
-  extendable: boolean;
-  onVoteCreate: (
+interface CommonProps {
+  _id?: string;
+  title?: string;
+  content?: string;
+  subtitle?: string;
+  choices?: string[];
+  extendable?: boolean;
+  onVoteCreate?: (
+    title: string,
+    content: string,
+    subtitle: string,
+    choices: string[]
+  ) => void;
+  onVoteEdit?: (
+    _id: string,
     title: string,
     content: string,
     subtitle: string,
@@ -26,7 +37,7 @@ interface FormInputs {
   subtitle: string;
 }
 
-const AdminContent: React.FC<Props> = ({
+export const AdminContentCreate: React.FC<CommonProps> = ({
   choices,
   extendable,
   onVoteCreate,
@@ -76,4 +87,62 @@ const AdminContent: React.FC<Props> = ({
   );
 };
 
-export default AdminContent;
+export const AdminContentEdit: React.FC<CommonProps> = ({
+  _id,
+  title,
+  content,
+  subtitle,
+  choices,
+  extendable,
+  onVoteEdit,
+}) => {
+  const { register, handleSubmit, errors, reset } = useForm<FormInputs>({
+    defaultValues: {
+      title: title,
+      content: content,
+      subtitle: subtitle,
+    },
+  });
+  const onSubmit = ({ title, content, subtitle }: FormInputs) => {
+    if (choices.length < 1) return;
+    onVoteEdit(_id, title, content, subtitle, choices);
+    reset();
+  };
+
+  return (
+    <AdminContentContainer onSubmit={handleSubmit(onSubmit)}>
+      <TitleInput
+        name="title"
+        placeholder="투표 제목을 입력하세요"
+        className={errors.title && 'error'}
+        ref={register({ required: true })}
+      />
+      <ContentTextArea
+        name="content"
+        placeholder="투표 내용을 입력하세요"
+        className={errors.content && 'error'}
+        ref={register({ required: true })}
+      />
+      <SubtitleInput
+        name="subtitle"
+        placeholder="의결문안을 입력하세요"
+        className={errors.subtitle && 'error'}
+        ref={register({ required: true })}
+      />
+      <ButtonGroup>
+        {choices.map(choice => (
+          // a button's default type is 'submit', but we don't want this button to submit
+          <BiseoButton type="button" nocursor key={choice}>
+            {choice}
+          </BiseoButton>
+        ))}
+        {extendable && <BiseoButton>+</BiseoButton>}
+      </ButtonGroup>
+      <ButtonGroup alignRight={true}>
+        <BiseoButton type="submit" background="#f2a024" foreground="#ffffff">
+          수정하기
+        </BiseoButton>
+      </ButtonGroup>
+    </AdminContentContainer>
+  );
+};

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -29,6 +29,8 @@ interface CommonProps {
     subtitle: string,
     choices: string[]
   ) => void;
+  onVoteDelete?: (_id: string) => void;
+  exitEditMode?: (_id: string) => void;
 }
 
 interface FormInputs {
@@ -95,6 +97,8 @@ export const AdminContentEdit: React.FC<CommonProps> = ({
   choices,
   extendable,
   onVoteEdit,
+  onVoteDelete,
+  exitEditMode,
 }) => {
   const { register, handleSubmit, errors, reset } = useForm<FormInputs>({
     defaultValues: {
@@ -140,7 +144,25 @@ export const AdminContentEdit: React.FC<CommonProps> = ({
       </ButtonGroup>
       <ButtonGroup alignRight={true}>
         <BiseoButton type="submit" background="#f2a024" foreground="#ffffff">
-          수정하기
+          수정
+        </BiseoButton>
+        <BiseoButton
+          type="button"
+          background="#f2a024"
+          foreground="#ffffff"
+          onClick={() => {
+            onVoteDelete(_id);
+          }}
+        >
+          삭제
+        </BiseoButton>
+        <BiseoButton
+          type="button"
+          onClick={() => {
+            exitEditMode(_id);
+          }}
+        >
+          취소
         </BiseoButton>
       </ButtonGroup>
     </AdminContentContainer>

--- a/src/components/AdminContent/index.ts
+++ b/src/components/AdminContent/index.ts
@@ -1,1 +1,1 @@
-export { default } from './AdminContent';
+export { AdminContentCreate, AdminContentEdit } from './AdminContent';

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -35,14 +35,39 @@ const UserMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
 };
 
 const AdminMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const [targetAgenda, setTargetAgenda] = useState<Agenda>();
+
+  const onEdit = (_id: string) => {
+    setTargetAgenda(agendas.find(agenda => agenda._id == _id));
+    setIsEdit(true);
+    console.log(_id);
+    console.log(isEdit);
+  };
+
+  const confirmEdit = (_id: string) => {
+    setIsEdit(false);
+  };
+
   return (
     <AdminMainContainer>
       <div className="admin">
-        <AdminBoard socket={socket} tabs={mockTabs} />
+        <AdminBoard
+          socket={socket}
+          tabs={mockTabs}
+          isEdit={isEdit}
+          targetAgenda={targetAgenda}
+          confirmEdit={confirmEdit}
+        />
       </div>
       <div className="agendas">
         {agendas.map(item => (
-          <AdminAgenda key={item._id} socket={socket} {...item} />
+          <AdminAgenda
+            key={item._id}
+            socket={socket}
+            onEdit={onEdit}
+            {...item}
+          />
         ))}
       </div>
     </AdminMainContainer>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -43,8 +43,6 @@ const AdminMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
       setTargetAgenda(agendas.find(agenda => agenda._id == _id));
     }
     setIsEdit(!isEdit);
-    console.log(_id);
-    console.log(isEdit);
   };
 
   const confirmEdit = (_id: string) => {

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -39,8 +39,10 @@ const AdminMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
   const [targetAgenda, setTargetAgenda] = useState<Agenda>();
 
   const onEdit = (_id: string) => {
-    setTargetAgenda(agendas.find(agenda => agenda._id == _id));
-    setIsEdit(true);
+    if (!isEdit) {
+      setTargetAgenda(agendas.find(agenda => agenda._id == _id));
+    }
+    setIsEdit(!isEdit);
     console.log(_id);
     console.log(isEdit);
   };


### PR DESCRIPTION
만든 투표를 수정/삭제할 수 있습니다.
(우선, 투표가 찬반 투표라고 가정했습니다. 다른 종류의 투표가 만들어지면 추가로 개발 필요합니다.)

agenda 목록의 edit icon을 클릭하면 agenda content에 투표 만들기 화면 대신 해당 투표의 내용이 보입니다.
* 수정 버튼을 누르면 수정이 됩니다.
* 삭제 버튼을 누르면 삭제가 됩니다.
* 취소 버튼을 누르면 투표 만들기 화면으로 돌아갑니다.

수정, 삭제 조건
* 투표 시작 전에만 수정이 가능합니다.
* 투표 중이 아닐 때만 삭제가 가능합니다.
=> 수정, 삭제가 불가능한 경우 버튼을 disabled 처리하였습니다.

투표의 edit icon 클릭
![image](https://user-images.githubusercontent.com/47997136/135490500-cc10dee0-9bc3-44f3-b241-0cf29cafaa64.png)

수정 완료 후 수정 버튼 클릭
![image](https://user-images.githubusercontent.com/47997136/135490529-7d8128ab-621e-4579-8bcf-196e2b640835.png)

진행 중인 투표는 수정, 삭제 불가능
![image](https://user-images.githubusercontent.com/47997136/135490635-a90590c4-1d80-4f9b-9b96-a4843866db56.png)

종료 된 투표는 수정 불가능, 삭제 가능
![image](https://user-images.githubusercontent.com/47997136/135490692-46b3ade8-2419-4eb1-9659-859925473f71.png)

삭제 버튼 클릭
![image](https://user-images.githubusercontent.com/47997136/135490720-a3cb5b5e-2c30-4344-a588-24f6eddd7518.png)



