### PR TITLE
refactor(AdminAgenda): content fontsize

### DIFF
--- a/src/components/AdminAgenda/AdminAgenda.tsx
+++ b/src/components/AdminAgenda/AdminAgenda.tsx
@@ -132,7 +132,12 @@ const AdminAgenda: React.FC<Props> = ({
   ) : (
     <AgendaContainer onClick={onClick} detailed={showDetails}>
       <AgendaContent>
-        {title}
+        <AgendaContentLeft>
+          <ActiveContainerTitle>{title}</ActiveContainerTitle>
+          <ActiveContainerProgress>
+            {`재석 ${totalParticipants}명 ${voteResultMessage}`}
+          </ActiveContainerProgress>
+        </AgendaContentLeft>
         <AgendaButton>
           <BiseoButton {...buttonProps()} onClick={onClickAdminAgenda}>
             {buttonText()}

--- a/src/components/UserAgenda/styled.tsx
+++ b/src/components/UserAgenda/styled.tsx
@@ -25,6 +25,8 @@ export const ActiveContainerContent = styled.div`
   margin: 20px 0px;
   padding: 15px 5px;
   white-space: pre-wrap;
+  font-size: 0.7rem;
+  font-weight: 400;
 `;
 
 export const ActiveContainerSubtitle = styled.div`


### PR DESCRIPTION
- adminAgenda에서 unextend시에도 progress를 표시하였습니다.
- content 폰트 사이즈/무게를 디자인에 맞게 변경하였습니다. (UserAgenda도 동일하게 변경)

<img width="573" alt="스크린샷 2021-11-25 오후 10 06 41" src="https://user-images.githubusercontent.com/60319371/143447022-58740b6c-3e5c-43cb-9da9-9ecd85f47270.png">

<img width="578" alt="스크린샷 2021-11-25 오후 10 06 49" src="https://user-images.githubusercontent.com/60319371/143447036-c0ac2547-359a-45e8-afb4-8e532c79323e.png">
>
