### PR TITLE
refactor(UserAgenda-style): word-wrap and overflow

### DIFF
--- a/src/components/AdminAgenda/AdminAgenda.tsx
+++ b/src/components/AdminAgenda/AdminAgenda.tsx
@@ -115,8 +115,8 @@ const AdminAgenda: React.FC<Props> = ({
   return showDetails ? (
     <AgendaContainer onClick={onClick} detailed={showDetails}>
       <AgendaContentLeft>
-        <ActiveContainerTitle>{title}</ActiveContainerTitle>
-        <ActiveContainerProgress>
+        <ActiveContainerTitle detailed>{title}</ActiveContainerTitle>
+        <ActiveContainerProgress detailed>
           {`재석 ${totalParticipants}명 ${voteResultMessage}`}
         </ActiveContainerProgress>
         <ActiveContainerContent>{content}</ActiveContainerContent>

--- a/src/components/UserAgenda/styled.tsx
+++ b/src/components/UserAgenda/styled.tsx
@@ -7,15 +7,23 @@ export const ActiveContainer = styled.div`
   padding: 30px;
 `;
 
-export const ActiveContainerTitle = styled.div`
+export const ActiveContainerTitle = styled.div<{ detailed?: boolean }>`
   font-size: 1.3rem;
   font-weight: 700;
+  ${({ detailed }) =>
+    detailed
+      ? 'word-wrap: break-word'
+      : 'overflow: hidden; text-overflow: ellipsis;'}
 `;
 
-export const ActiveContainerProgress = styled.div`
+export const ActiveContainerProgress = styled.div<{ detailed?: boolean }>`
   font-size: 1rem;
   font-weight: 400;
   margin-top: 20px;
+  ${({ detailed }) =>
+    detailed
+      ? 'word-wrap: break-word'
+      : 'overflow: hidden; text-overflow: ellipsis;'}
 `;
 
 export const ActiveContainerContent = styled.div`
@@ -24,14 +32,15 @@ export const ActiveContainerContent = styled.div`
   border-top: 1px solid #f2a024;
   margin: 20px 0px;
   padding: 15px 5px;
-  white-space: pre-wrap;
   font-size: 0.7rem;
   font-weight: 400;
+  word-wrap: break-word;
 `;
 
 export const ActiveContainerSubtitle = styled.div`
   font-weight: 700;
   margin-bottom: 15px;
+  word-wrap: break-word;
 `;
 
 export const InactiveContainer = styled.div`


### PR DESCRIPTION
UserAgenda의 style을 변경하였습니다. AdminAgenda에서도 UserAgenda의 style을 사용하여 변경하였습니다.
확장 전에 제목/투표상황이 글자수가 넘칠시 '...'으로 표시하도록 하였고,
확장 후에 글자수가 정해진 너비를 초과하는 경우가 있어 너비를 초과하지 않게 수정하였습니다

![스크린샷 2021-12-28 오후 10 40 40](https://user-images.githubusercontent.com/60319371/147572929-19850831-5ad5-4239-ae66-ada232cc1426.png)
![스크린샷 2021-12-28 오후 10 40 47](https://user-images.githubusercontent.com/60319371/147572931-f2686117-513c-4728-b15a-dd17ab0e0e37.png)
