### PR TITLE
fix(chat): fix duplicate chat

### DIFF
--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -2,10 +2,11 @@ import { useState, useEffect, useCallback } from 'react';
 import axios from '@/utils/axios';
 import { MessageType } from '@/common/types';
 
-function useFetch(query: string, page: number) {
-  const [loading, setLoading] = useState(true);
+function useFetch(query: string) {
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [list, setList] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
 
   const sendQuery = useCallback(async () => {
     try {
@@ -17,16 +18,17 @@ function useFetch(query: string, page: number) {
         .catch(() => ({ data: [] }));
       const chatlogs: MessageType[] = data.chats ?? [];
 
+      setHasMore(chatlogs.length > 0);
       setList(prev => prev.concat(chatlogs));
       setLoading(false);
     } catch (err) {
       setError(err);
     }
-  }, [page]);
+  }, [query]);
 
   useEffect(() => {
-    sendQuery();
-  }, [query, sendQuery, page]);
+    if (hasMore) sendQuery();
+  }, [query]);
 
   return { loading, list, error };
 }


### PR DESCRIPTION
문제 상황
처음에 채팅을 중복해서 불러옴

원인
이전 채팅을 불러오는 방식이 마지막 chat의 id와 page 번호 두 가지가 있어서 두 번 불러오는 문제 발생

해결
마지막 chat의 id만을 사용해서 이전 채팅을 불러옴
-> page 삭제, query만 사용