### PR TITLE
feat(header): adjust vacant function

### DIFF
--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -19,5 +19,10 @@ export enum LoginStatus {
 export enum AwayStatus {
   Entered,
   Vacant,
-  Staying,
+}
+
+export enum MemberState {
+  ONLINE = 'online',
+  OFFLINE = 'offline',
+  VACANT = 'vacant',
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { MdSettings, MdAccountCircle } from 'react-icons/md';
 import HomeIcon from './homeIcon.svg';
@@ -23,7 +23,11 @@ import { logout } from '@/utils/auth';
 import { logout as logoutAction } from '@/store/slices/login';
 import { setUser } from '@/store/slices/user';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  socket: SocketIOClient.Socket;
+}
+
+const Header: React.FC<HeaderProps> = ({ socket }) => {
   const title = useTitle();
   const history = useHistory();
   const location = useLocation();
@@ -33,7 +37,6 @@ const Header: React.FC = () => {
   const [awayState, setAwayState] = useState<AwayStatus>(AwayStatus.Entered);
   const [buttonString, setButtonString] = useState<string>('enter');
   const [buttonColor, setButtonColor] = useState<string>(COLOR.primary);
-
   const handleLogout = () => {
     logout();
     dispatch(logoutAction());
@@ -47,14 +50,13 @@ const Header: React.FC = () => {
         setAwayState(AwayStatus.Vacant);
         setButtonString('vacant');
         setButtonColor(COLOR.vacant);
+        socket.emit('vacant:on');
         break;
       case AwayStatus.Vacant:
-        setAwayState(AwayStatus.Staying);
-        break;
-      case AwayStatus.Staying:
         setAwayState(AwayStatus.Entered);
         setButtonString('enter');
         setButtonColor(COLOR.primary);
+        socket.emit('vacant:off');
         break;
     }
   };
@@ -67,11 +69,7 @@ const Header: React.FC = () => {
     awayState !== AwayStatus.Entered ? VacantContainer : EnteredContainer;
 
   const AwayStateMessage =
-    awayState === AwayStatus.Entered
-      ? ''
-      : awayState === AwayStatus.Vacant
-      ? '자리비움 상태입니다.'
-      : '현재 투표가 진행중입니다. 다음 투표부터 참여 할 수 있습니다.';
+    awayState === AwayStatus.Entered ? '' : '자리비움 상태입니다.';
 
   const userPagePath = '/';
   const adminPagePath = '/admin';

--- a/src/components/VoterChoice/Orange.svg
+++ b/src/components/VoterChoice/Orange.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4" cy="4" r="4" fill="#FFBF43"/>
+</svg>

--- a/src/components/VoterChoice/VoterChoice.tsx
+++ b/src/components/VoterChoice/VoterChoice.tsx
@@ -11,6 +11,8 @@ import { ActiveContainerTitle } from '../UserAgenda/styled';
 import BiseoButton from '../BiseoButton';
 import Green from './Green.svg';
 import Red from './Red.svg';
+import Orange from './Orange.svg';
+import { MemberState } from '@/common/enums';
 
 interface VoterChoiceProps {
   users: User[];
@@ -28,7 +30,7 @@ interface User {
   uid: string;
   sparcsId: string;
   isVotable: boolean;
-  isOnline: boolean;
+  state: MemberState;
 }
 
 const VoterChoice: React.FC<VoterChoiceProps> = ({
@@ -98,7 +100,13 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                       key={index}
                     >
                       {user.sparcsId} &nbsp;
-                      {user.isOnline ? <Green /> : <Red />}
+                      {user.state === MemberState.ONLINE ? (
+                        <Green />
+                      ) : user.state === MemberState.VACANT ? (
+                        <Orange />
+                      ) : (
+                        <Red />
+                      )}
                     </BiseoButton>
                   );
                 }
@@ -116,7 +124,13 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                     }}
                   >
                     {user.sparcsId} &nbsp;
-                    {user.isOnline ? <Green /> : <Red />}
+                    {user.state === MemberState.ONLINE ? (
+                      <Green />
+                    ) : user.state === MemberState.VACANT ? (
+                      <Orange />
+                    ) : (
+                      <Red />
+                    )}
                   </BiseoButton>
                 );
               } else {
@@ -126,7 +140,13 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                     onClick={() => select([user.uid, ...selectedUsers])}
                   >
                     {user.sparcsId} &nbsp;
-                    {user.isOnline ? <Green /> : <Red />}
+                    {user.state === MemberState.ONLINE ? (
+                      <Green />
+                    ) : user.state === MemberState.VACANT ? (
+                      <Orange />
+                    ) : (
+                      <Red />
+                    )}
                   </BiseoButton>
                 );
               }

--- a/src/pages/AdminPage/AdminPage.tsx
+++ b/src/pages/AdminPage/AdminPage.tsx
@@ -1,9 +1,7 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import io from 'socket.io-client';
+import React, { useState, useEffect } from 'react';
 import { Agenda } from '@/common/types';
 import AdminBoard from '@/components/AdminBoard';
 import AdminAgenda from '@/components/AdminAgenda';
-import { getToken } from '@/utils/auth';
 import axios from '@/utils/axios';
 import { mockTabs } from './mock';
 import { AdminMainContainer } from './styled';
@@ -54,19 +52,13 @@ const AdminMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
   );
 };
 
-const AdminPage: React.FC = () => {
+interface AdminPageProps {
+  socket: SocketIOClient.Socket;
+}
+
+const AdminPage: React.FC<AdminPageProps> = ({ socket }) => {
   const [agendas, setAgendas] = useState<Agenda[]>([]);
   const [valid, setValid] = useState(true);
-
-  const socket = useMemo(
-    () =>
-      io(process.env.SERVER_URL, {
-        transports: ['websocket'],
-        upgrade: false,
-        query: `token=${getToken()}`,
-      }),
-    []
-  );
 
   socket.on('error', (err: Error) => {
     setValid(false);

--- a/src/pages/App/App.tsx
+++ b/src/pages/App/App.tsx
@@ -1,24 +1,31 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { GlobalStyle } from '@/common/style';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { AuthedRoute, AdminAuthedRoute } from '@/components/AuthedRoute';
-import {
-  Login,
-  LoginRedirect,
-  LoginCallback,
-  Dashboard,
-  Main,
-  AdminPage,
-} from '@/pages';
+import { Login, LoginRedirect, LoginCallback, Main, AdminPage } from '@/pages';
 import BiseoToastContainer from '@/components/BiseoToastContainer';
 import Header from '@/components/Header';
 import { AppContainer } from './styled';
+import io from 'socket.io-client';
+import { getToken } from '@/utils/auth';
+import { useTypedSelector } from '@/hooks';
 
 const App: React.FC = () => {
+  const isLoggedIn = useTypedSelector(state => state.loggedIn);
+  const socket = useMemo(
+    () =>
+      io(process.env.SERVER_URL, {
+        transports: ['websocket'],
+        upgrade: false,
+        query: `token=${getToken()}`,
+      }),
+    [isLoggedIn]
+  );
+
   return (
     <Router>
       <GlobalStyle />
-      <Header />
+      <Header socket={socket} />
       <AppContainer>
         <Switch>
           <Route exact path="/login/redirect">
@@ -31,10 +38,10 @@ const App: React.FC = () => {
             <Login />
           </Route>
           <AdminAuthedRoute path="/admin">
-            <AdminPage />
+            <AdminPage socket={socket} />
           </AdminAuthedRoute>
           <AuthedRoute path="/">
-            <Main />
+            <Main socket={socket} />
           </AuthedRoute>
         </Switch>
       </AppContainer>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import io from 'socket.io-client';
+import React, { useState, useEffect } from 'react';
 import { Agenda } from '@/common/types';
 import { AgendaStatus } from '@/common/enums';
 import ChatBox from '@/components/ChatBox';
 import UserAgenda from '@/components/UserAgenda';
-import { getToken } from '@/utils/auth';
 import axios from '@/utils/axios';
 import { UserMainContainer } from './styled';
 import { Redirect } from 'react-router-dom';
@@ -31,19 +29,13 @@ const UserMain: React.FC<CommonMainProps> = ({ socket, agendas }) => {
   );
 };
 
-const Main: React.FC = () => {
+interface MainProps {
+  socket: SocketIOClient.Socket;
+}
+
+const Main: React.FC<MainProps> = ({ socket }) => {
   const [agendas, setAgendas] = useState<Agenda[]>([]);
   const [valid, setValid] = useState(true);
-
-  const socket = useMemo(
-    () =>
-      io(process.env.SERVER_URL, {
-        transports: ['websocket'],
-        upgrade: false,
-        query: `token=${getToken()}`,
-      }),
-    []
-  );
 
   socket.on('error', (err: Error) => {
     setValid(false);


### PR DESCRIPTION
## 주요 변경 사항

- Header에 자리비움 실질적인 기능을 추가했습니다.
- enum MemberState에 `VACANT`를 추가했습니다.
- 자리비움을 클릭할 경우, Admin이 대상을 선택할 시에 상태 표시가 주황색으로 표시가 됩니다. 

<img width="1419" alt="스크린샷 2022-03-01 오후 4 14 18" src="https://user-images.githubusercontent.com/60319371/156122392-16b259ba-647c-417b-ba41-76b53f5ce25c.png">
<img width="802" alt="스크린샷 2022-03-01 오후 4 14 29" src="https://user-images.githubusercontent.com/60319371/156122401-abc5e536-3f00-48b4-bb25-211060ac96c9.png">

