### PR TITLE
feat(user agenda): show details

### DIFF
--- a/src/components/AdminAgenda/styled.tsx
+++ b/src/components/AdminAgenda/styled.tsx
@@ -43,6 +43,12 @@ export const AgendaButton = styled.div`
   display: flex;
 `;
 
+export const AgendaContentAll = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
 export const AgendaContentLeft = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/UserAgenda/UserAgenda.tsx
+++ b/src/components/UserAgenda/UserAgenda.tsx
@@ -7,9 +7,19 @@ import {
   ActiveContainerTitle,
   ActiveContainerContent,
   ActiveContainerSubtitle,
+  ActiveContainerProgress,
   ButtonGroup,
   InactiveContainer,
 } from './styled';
+import {
+  AgendaContainer,
+  AgendaContent,
+  AgendaButton,
+  AgendaContentLeft,
+  AgendaNotVote,
+  AgendaNotVoteList,
+  AgendaContentAll,
+} from '../AdminAgenda/styled';
 
 interface Props extends Agenda {
   socket: SocketIOClient.Socket;
@@ -36,6 +46,11 @@ const UserAgenda: React.FC<Props> = ({
   const [alreadySubmitted, setAlreadySubmitted] = useState<boolean>(
     userChoice !== null
   );
+  const [showDetails, setShowDetails] = useState(false);
+
+  const onClick = () => {
+    setShowDetails(!showDetails);
+  };
 
   const active = Date.now() < Date.parse(expires);
 
@@ -129,8 +144,19 @@ const UserAgenda: React.FC<Props> = ({
         </BiseoButton>
       </ButtonGroup>
     </ActiveContainer>
+  ) : showDetails ? (
+    <AgendaContainer onClick={onClick} detailed={showDetails}>
+      <AgendaContentAll>
+        <ActiveContainerTitle detailed>{title}</ActiveContainerTitle>
+        <ActiveContainerProgress detailed>
+          {`재석 ${totalParticipants}명 ${voteResultMessage}`}
+        </ActiveContainerProgress>
+        <ActiveContainerContent>{content}</ActiveContainerContent>
+        <ActiveContainerSubtitle>{subtitle}</ActiveContainerSubtitle>
+      </AgendaContentAll>
+    </AgendaContainer>
   ) : (
-    <InactiveContainer>
+    <InactiveContainer onClick={onClick}>
       <div className="title">{title}</div>
       <div className="result-info">{`재석 ${totalParticipants}명 ${voteResultMessage}`}</div>
     </InactiveContainer>


### PR DESCRIPTION
user가 main page에서 종료된 투표의 detail을 확인할 수 있도록 수정하였습니다.

<img width="691" alt="image" src="https://user-images.githubusercontent.com/47997136/167376438-2ac0f0b9-8b66-49f1-aac5-ba45f80b627e.png">
