### PR TITLE
refactor(participants): change into sparcs_Id

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -22,7 +22,6 @@ export interface MessageType {
 
 // user type used for redux state
 export interface User {
-  ssoUID: string;
   sparcsID: string;
 }
 

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -161,14 +161,14 @@ export function useUsers(
 
   async function updateUsers(_preset: number) {
     const _users = users.map(user => {
-      if (selectedUsers.includes(user.uid)) {
+      if (selectedUsers.includes(user.sparcsId)) {
         return {
-          uid: user.uid,
+          sparcs_id: user.sparcsId,
           isVotable: true,
         };
       } else {
         return {
-          uid: user.uid,
+          sparcs_id: user.sparcsId,
           isVotable: false,
         };
       }
@@ -193,7 +193,7 @@ export function useUsers(
       setPreset(n);
       const _selectedUser = _users
         .filter(user => user.isVotable)
-        .map(user => user.uid);
+        .map(user => user.sparcsId);
       setSelectedUsers(_selectedUser);
     }
   };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -56,7 +56,7 @@ const Header: React.FC<HeaderProps> = ({ socket }) => {
   const handleLogout = () => {
     logout();
     dispatch(logoutAction());
-    dispatch(setUser({ sparcsID: null, ssoUID: null }));
+    dispatch(setUser({ sparcsID: null }));
     setIsSubmenu(false);
     history.replace('/login');
   };

--- a/src/components/UserAgenda/UserAgenda.tsx
+++ b/src/components/UserAgenda/UserAgenda.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, Fragment } from 'react';
 import { toast } from 'react-toastify';
 import BiseoButton from '@/components/BiseoButton';
 import { Agenda } from '@/common/types';
@@ -11,15 +11,7 @@ import {
   ButtonGroup,
   InactiveContainer,
 } from './styled';
-import {
-  AgendaContainer,
-  AgendaContent,
-  AgendaButton,
-  AgendaContentLeft,
-  AgendaNotVote,
-  AgendaNotVoteList,
-  AgendaContentAll,
-} from '../AdminAgenda/styled';
+import { AgendaContainer, AgendaContentAll } from '../AdminAgenda/styled';
 
 interface Props extends Agenda {
   socket: SocketIOClient.Socket;
@@ -122,12 +114,12 @@ const UserAgenda: React.FC<Props> = ({
     <ActiveContainer>
       <ActiveContainerTitle>{title}</ActiveContainerTitle>
       <ActiveContainerContent>
-        {content.split('\n').map(line => {
+        {content.split('\n').map((line, i) => {
           return (
-            <>
+            <Fragment key={i}>
               {line}
               <br />
-            </>
+            </Fragment>
           );
         })}
       </ActiveContainerContent>
@@ -162,7 +154,16 @@ const UserAgenda: React.FC<Props> = ({
         <ActiveContainerProgress detailed>
           {`재석 ${totalParticipants}명 ${voteResultMessage}`}
         </ActiveContainerProgress>
-        <ActiveContainerContent>{content}</ActiveContainerContent>
+        <ActiveContainerContent>
+          {content.split('\n').map((line, i) => {
+            return (
+              <Fragment key={i}>
+                {line}
+                <br />
+              </Fragment>
+            );
+          })}
+        </ActiveContainerContent>
         <ActiveContainerSubtitle>{subtitle}</ActiveContainerSubtitle>
       </AgendaContentAll>
     </AgendaContainer>

--- a/src/components/VoterChoice/VoterChoice.tsx
+++ b/src/components/VoterChoice/VoterChoice.tsx
@@ -73,7 +73,7 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                 <BiseoButton
                   background="#f2a024"
                   foreground="#ffffff"
-                  onClick={() => select(users.map(user => user.uid))}
+                  onClick={() => select(users.map(user => user.sparcsId))}
                   style={{ marginRight: '5px' }}
                 >
                   전체 선택
@@ -112,7 +112,7 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                     />
                   );
                 }
-              } else if (selectedUsers.includes(user.uid)) {
+              } else if (selectedUsers.includes(user.sparcsId)) {
                 return (
                   <UserCheckButton
                     key={i}
@@ -120,7 +120,9 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                     user={user}
                     onClick={() => {
                       const temp = [...selectedUsers];
-                      const idx = temp.findIndex(uid => uid === user.uid);
+                      const idx = temp.findIndex(
+                        sparcsId => sparcsId === user.sparcsId
+                      );
                       temp.splice(idx, 1);
                       select(temp);
                     }}
@@ -132,7 +134,7 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                     key={i}
                     active={false}
                     user={user}
-                    onClick={() => select([user.uid, ...selectedUsers])}
+                    onClick={() => select([user.sparcsId, ...selectedUsers])}
                   />
                 );
               }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -26,7 +26,7 @@ export const useAuth = (): LoginStatus => {
       .catch(() => {
         setLoggedIn(LoginStatus.NotLoggedIn);
         dispatch(logout());
-        dispatch(setUser({ sparcsID: null, ssoUID: null }));
+        dispatch(setUser({ sparcsID: null }));
       });
   });
 

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -66,7 +66,7 @@ const Main: React.FC<MainProps> = ({ socket }) => {
         data.agendas.filter(
           agenda =>
             isUndefined(agenda.participants) ||
-            agenda.participants.includes(user.ssoUID)
+            agenda.participants.includes(user.sparcsID)
         ) ?? [];
       setAgendas(agendas);
     }

--- a/src/store/slices/user.ts
+++ b/src/store/slices/user.ts
@@ -2,7 +2,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { User } from '@/common/types';
 
 const initialState: User = {
-  ssoUID: null,
   sparcsID: null,
 };
 


### PR DESCRIPTION
## 주요 사항
- 로그인하지 않은 유저(DB에 저장되지 않는 유저)들도 안건 대상 선택에서 할 수 있도록 선작업입니다.
- Agenda의 participants 내용이 uid에서 sparcs_id로 변경되었습니다.
- redux store에서 ssoUID 항목을 삭제했습니다.