### PR TITLE
refactor(chat): broadcast(enter/out)

### DIFF
--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -1,8 +1,6 @@
 export enum MessageEnum {
-  NEW = 'new',
   MEMBERS = 'members',
   MESSAGE = 'message',
-  OUT = 'out',
 }
 
 export enum AgendaStatus {

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -67,6 +67,7 @@ interface User {
 
 interface UseUsersType {
   users: User[];
+  addUser: (user: string) => Promise<void>;
   selectedUsers: string[];
   setSelectedUsers: React.Dispatch<React.SetStateAction<string[]>>;
   preset: number;
@@ -159,6 +160,18 @@ export function useUsers(
     };
   }, [users]);
 
+  async function addUser(user: string) {
+    type Response = { data: { success: boolean; user: User } };
+    const response: Response = await axios
+      .post('/users', {
+        sparcsId: user,
+      })
+      .catch(() => {
+        throw new Error('Error: Add user Failed');
+      });
+    if (response.data.success) setUsers([...users, response.data.user]);
+  }
+
   async function updateUsers(_preset: number) {
     const _users = users.map(user => {
       if (selectedUsers.includes(user.sparcsId)) {
@@ -200,6 +213,7 @@ export function useUsers(
 
   return {
     users,
+    addUser,
     selectedUsers,
     setSelectedUsers,
     preset,
@@ -224,6 +238,7 @@ export const AdminContentCreate: React.FC<AdminContentCreateProps> = ({
 
   const {
     users,
+    addUser,
     selectedUsers,
     setSelectedUsers,
     preset,
@@ -423,6 +438,7 @@ export const AdminContentCreate: React.FC<AdminContentCreateProps> = ({
       </AdminContentContainer>
       <VoterChoice
         users={users}
+        addUser={addUser}
         shown={isVoterChoice}
         preset={preset}
         handlePreset={clickPreset}
@@ -463,6 +479,7 @@ export const AdminContentEdit: React.FC<AdminContentEditProps> = ({
 
   const {
     users,
+    addUser,
     selectedUsers,
     setSelectedUsers,
     preset,
@@ -563,6 +580,7 @@ export const AdminContentEdit: React.FC<AdminContentEditProps> = ({
       </AdminContentContainer>
       <VoterChoice
         users={users}
+        addUser={addUser}
         shown={isVoterChoice}
         preset={preset}
         handlePreset={clickPreset}

--- a/src/components/AdminContent/AdminContent.tsx
+++ b/src/components/AdminContent/AdminContent.tsx
@@ -314,6 +314,7 @@ export const AdminContentCreate: React.FC<AdminContentCreateProps> = ({
   const enterPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') addNewChoice();
+      if (e.key === 'Escape') setExpand(false);
     },
     [newChoice]
   );
@@ -401,7 +402,7 @@ export const AdminContentCreate: React.FC<AdminContentCreateProps> = ({
               {expand ? (
                 <InputNewChoice
                   onChange={handleNewChoice}
-                  onKeyPress={enterPress}
+                  onKeyUp={enterPress}
                 />
               ) : (
                 <BiseoButton onClick={() => setExpand(true)}>+</BiseoButton>
@@ -517,6 +518,7 @@ export const AdminContentEdit: React.FC<AdminContentEditProps> = ({
             name="title"
             className={errors.title && 'error'}
             ref={register({ required: true })}
+            style={{ width: '100%', marginRight: '5px' }}
           />
           <BiseoButton
             type="button"

--- a/src/components/AdminContent/AdminContentCreateAuto.tsx
+++ b/src/components/AdminContent/AdminContentCreateAuto.tsx
@@ -36,6 +36,7 @@ const AdminContentCreateAuto: React.FC<AdminContentCreateProps> = ({
 
   const {
     users,
+    addUser,
     selectedUsers,
     setSelectedUsers,
     preset,
@@ -195,6 +196,7 @@ const AdminContentCreateAuto: React.FC<AdminContentCreateProps> = ({
       </AdminContentContainer>
       <VoterChoice
         users={users}
+        addUser={addUser}
         shown={isVoterChoice}
         preset={preset}
         handlePreset={clickPreset}

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -52,14 +52,14 @@ const Message: React.FC<MessageProps> = ({ message }) => {
     }
   })();
 
-  const user =
-    message.type === MessageEnum.MESSAGE ? message.username || 'Me' : '';
   const date =
     message.type === MessageEnum.MESSAGE ? parseDate(message.date) : null;
 
   return (
-    <MessageContainer justification={justification}>
-      {user && <MessageUsername>{user}</MessageUsername>}
+    <MessageContainer username={message.username}>
+      {message.username && (
+        <MessageUsername>{message.username}</MessageUsername>
+      )}
       <MessageContent username={message.username}>
         {content}
         {date && (
@@ -204,6 +204,7 @@ const ChatBox: React.FC<Props> = ({ socket }) => {
     setChatlog([
       {
         type: MessageEnum.MESSAGE,
+        username: '',
         message: msgObject.message,
         date: msgObject.date,
       },

--- a/src/components/ChatBox/styled.tsx
+++ b/src/components/ChatBox/styled.tsx
@@ -8,6 +8,7 @@ export const ChatBoxExternalContainer = styled.div`
 `;
 
 export const ChatBoxInternalContainer = styled.div`
+  position: relative;
   background-color: #ffffff;
   box-sizing: border-box;
   height: 100%;
@@ -18,14 +19,16 @@ export const ChatBoxInternalContainer = styled.div`
 export const ChatBoxParticipantsBox = styled.div`
   visibility: hidden;
   position: absolute;
+  right: 3%;
   background-color: #ffffff;
   box-sizing: border-box;
   border: 1px solid #f2a024;
   border-radius: 10px;
-  margin-top: 20px;
+  margin-top: 0px;
   padding: 10px 20px;
   width: 180px;
-  height: 30%;
+  height: 35%;
+  max-height: 300px;
   display: flex;
   flex-direction: column;
   z-index: 1;
@@ -39,9 +42,10 @@ export const ChatBoxParticipantsBox = styled.div`
 `;
 
 export const ChatBoxParticipants = styled.div`
-  display: flex;
+  display: block;
   font-size: 0.9rem;
   padding: 10px 20px;
+  text-align: right;
 
   &:hover ${ChatBoxParticipantsBox} {
     visibility: visible;
@@ -146,8 +150,8 @@ export const MessageUsername = styled.span`
   position: absolute;
 `;
 
-export const MessageContent = styled.div`
-  background-color: #f7f6f3;
+export const MessageContent = styled.div<{ username: string }>`
+  background-color: ${props => (props.username === '' ? '#fec46c' : '#f7f6f3')};
   border-radius: 10px;
   box-sizing: border-box;
   font-size: 18px;
@@ -187,4 +191,23 @@ export const ChatBoxScrollable = styled.div`
   height: calc(100% - 50px);
   overflow: auto;
   padding: 0px 40px;
+`;
+
+export const ChatBroadcast = styled.div<{ visible: boolean }>`
+  visibility: ${props => (props.visible ? 'visible' : 'hidden')};
+  opacity: ${props => (props.visible ? '1' : '0')};
+  display: flex;
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%);
+  background-color: #111111cc;
+  border-radius: 10px;
+  box-sizing: border-box;
+  font-size: 1rem;
+  color: #ffffff;
+  max-width: 90%;
+  padding: 7px 20px;
+  word-break: break-word;
+  transition: visibility 0.4s linear, opacity 0.3s linear;
+  z-index: 1;
 `;

--- a/src/components/ChatBox/styled.tsx
+++ b/src/components/ChatBox/styled.tsx
@@ -94,7 +94,8 @@ export const ChatBoxInputGroup = styled.div`
     }
 
     &:hover {
-      background-color: #f7f3e9;
+      filter: brightness(0.98);
+      transition: filter 0.2s linear;
     }
   }
 `;
@@ -103,16 +104,10 @@ interface JustificationProps {
   justification: string;
 }
 
-export const MessageContainer = styled.div`
+export const MessageContainer = styled.div<{ username: string }>`
   display: flex;
-  justify-content: ${(props: JustificationProps) =>
-    props.justification === 'around'
-      ? 'space-around'
-      : `flex-${props.justification}`};
-  margin-top: ${(props: JustificationProps) =>
-    props.justification === 'around' ? '20px' : '50px'};
-  ${(props: JustificationProps) =>
-    props.justification === 'around' && `font-weight: bold`};
+  justify-content: ${props => (props.username ? 'flex-start' : 'flex-end')};
+  margin-top: ${props => (props.username ? '35px' : '10px')};
   position: relative;
   max-width: 100%;
 

--- a/src/components/UserAgenda/styled.tsx
+++ b/src/components/UserAgenda/styled.tsx
@@ -51,6 +51,7 @@ export const InactiveContainer = styled.div`
   box-shadow: 2px 2px 5px 1px rgba(0, 0, 0, 0.25);
   padding: 15px 30px;
   position: relative;
+  cursor: pointer;
 
   &::before {
     background: #f2a024;
@@ -72,6 +73,11 @@ export const InactiveContainer = styled.div`
 
   & > .result-info {
     font-size: 0.8rem;
+  }
+
+  &:hover {
+    filter: brightness(0.98);
+    transition: filter 0.3s linear;
   }
 `;
 

--- a/src/components/VoterChoice/VoterChoice.tsx
+++ b/src/components/VoterChoice/VoterChoice.tsx
@@ -8,6 +8,7 @@ import {
   VoterChoiceBottom,
   PresetChoiceContainer,
   CheckButton,
+  CheckButtonInput,
 } from './styled';
 import BiseoButton from '../BiseoButton';
 import Green from '@/public/Green.svg';
@@ -17,6 +18,7 @@ import { MemberState } from '@/common/enums';
 
 interface VoterChoiceProps {
   users: User[];
+  addUser: (user: string) => void;
   shown: boolean;
   preset: number;
   handlePreset: (n: number) => void;
@@ -36,6 +38,7 @@ interface User {
 
 const VoterChoice: React.FC<VoterChoiceProps> = ({
   users,
+  addUser,
   shown,
   preset,
   handlePreset,
@@ -46,6 +49,8 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
   updateUsers,
 }) => {
   const [expand, setExpand] = useState<boolean>(false);
+  const [addMode, setAddMode] = useState<boolean>(false);
+  const [userName, setUserName] = useState<string>('');
 
   useEffect(() => {
     if (selectedUsers.length === 0) setExpand(false);
@@ -53,6 +58,15 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
   const addPreset = (_preset: number) => {
     setExpand(false);
     updateUsers(_preset);
+  };
+
+  const enterPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      addUser(userName);
+      setAddMode(false);
+      setUserName('');
+    }
+    if (e.key === 'Escape') setAddMode(false);
   };
 
   return (
@@ -139,6 +153,20 @@ const VoterChoice: React.FC<VoterChoiceProps> = ({
                 );
               }
             })}
+            {preset === 0 &&
+              (addMode ? (
+                <CheckButtonInput
+                  onChange={e => setUserName(e.target.value)}
+                  onKeyUp={enterPress}
+                />
+              ) : (
+                <CheckButton
+                  onClick={() => setAddMode(true)}
+                  style={{ justifyContent: 'center' }}
+                >
+                  +
+                </CheckButton>
+              ))}
           </VoterList>
           <VoterChoiceBottom>
             <BiseoButton onClick={close} style={{ marginRight: '0px' }}>
@@ -214,11 +242,7 @@ const UserCheckButton: React.FC<UserCheckButtonProps> = ({
   onClick,
 }) => {
   return (
-    <CheckButton
-      check={active}
-      onClick={onClick}
-      style={{ marginBottom: '12px' }}
-    >
+    <CheckButton check={active} onClick={onClick}>
       <span
         style={{
           textOverflow: 'ellipsis',

--- a/src/components/VoterChoice/styled.tsx
+++ b/src/components/VoterChoice/styled.tsx
@@ -109,7 +109,7 @@ export const CheckButton = styled.button<{
   align-items: center;
   justify-content: space-between;
   margin-right: 5px;
-  margin-bottom: 5px;
+  margin-bottom: 12px;
   padding: 0px 10px;
   white-space: nowrap;
   overflow: hidden;
@@ -126,4 +126,21 @@ export const CheckButton = styled.button<{
     transform: translateY(0.5px);
     box-shadow: 1px 2px 5px -1px rgba(0, 0, 0, 0.6);
   }
+`;
+
+export const CheckButtonInput = styled.input`
+  width: 108px;
+  min-height: 43px;
+  background-color: #ffffff;
+  border: 1px solid #d6d6d6;
+  border-radius: 5px;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  color: #000000;
+  display: inline-flex;
+  font-size: 1rem;
+  align-items: center;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  padding: 0px 5px;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
## 주요 사항
- 채팅 Enter/Out 알람 UI를 변경했습니다.
  - 기존에는 채팅창에서 표시되는 알람은 채팅창을 가리는 단점을 가졌습니다.
- 상대방 채팅을 가지리 않기 위해 참여 목록 창을 우측으로 이동했습니다.
- 상대방과 본인의 채팅을 더 명확히 구분하기 위해 본인의 채팅 풍선에 배경을 추가했습니다.

<img width="616" alt="스크린샷 2022-05-29 오후 3 45 39" src="https://user-images.githubusercontent.com/60319371/170857152-8a0354a6-d78c-4752-95ce-2c4c1533f5b9.png">
<img width="563" alt="스크린샷 2022-05-29 오후 3 45 26" src="https://user-images.githubusercontent.com/60319371/170857149-f917a8f0-3e6d-402c-a6c4-cd49b03d6ccc.png">
<img width="572" alt="스크린샷 2022-05-29 오후 5 03 12" src="https://user-images.githubusercontent.com/60319371/170858456-9a371ad5-600f-437b-b2c8-cdda5369b876.png">

